### PR TITLE
Fix markdown codeblock in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,6 @@ database_id = "<unique-ID-for-your-database>"
 To init local database and run server locally:
 
 ```bash
-
-```bash
 wrangler d1 execute <DATABASE_NAME> --local --file server/db/migrations/0000_cultured_fixer.sql
 wrangler dev --local --persist
 ```


### PR DESCRIPTION
Corrected extra ```bash in the README.

Thanks for the great example of how to get this stack running on CF with D1. 

Looking forward to giving it a try! 🚀